### PR TITLE
Error return code if nginx fails to start

### DIFF
--- a/nginx
+++ b/nginx
@@ -219,9 +219,16 @@ start() {
         start-stop-daemon --start --quiet --chuid \
         $RUNAS --pidfile $PIDSPATH/$PIDFILE --exec $DAEMON \
         -- -c $NGINX_CONF_FILE
+        status=$?
         setFilePerms
-        log_end_msg $SCRIPT_OK
-        rc=0
+
+        if [ "${status}" -eq 0 ]; then
+            log_end_msg $SCRIPT_OK
+            rc=0
+        else
+            log_end_msg $SCRIPT_ERROR
+            rc=7
+        fi
     fi
 
     return


### PR DESCRIPTION
Because of this:

```
 λ deploy at reploy in /etc/init.d
 → sudo service nginx start
 * Starting Nginx Server...                                                                                                                           nginx: [emerg] mkdir() "/usr/local/var/run/nginx/client_body_temp" failed (2: No such file or directory)
                                                                                                                                               [ OK ]
 λ deploy at reploy in /etc/init.d
 → echo $?
0
```

Also various orchestration tools, such as Ansible for example, that relies on exit codes shows that nginx started successful, although this is not true.
